### PR TITLE
refactor: replace C-style strcmp with modern C++ string comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,10 @@
 *.exe
 *.out
 *.app
+
+# Generated files
+src/i18n/*
+
+# Generated build files
+compile_commands.json
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,11 @@ set(PROJECT_SOURCES
     src/mainwindow.ui
     src/mainwindow.cpp src/mainwindow.h
     src/operate.cpp src/operate.h
+    src/cli.cpp src/cli.h
     src/helper.cpp src/helper.h
     src/msi-ec_helper.cpp src/msi-ec_helper.h
     src/settings.cpp src/settings.h
+    src/options.cpp src/options.h
     src/resources.qrc
 )
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MControlCenter
 
+## Temporary (hopefully) fork with CLI support until upstream merge
+
 MControlCenter is a Free and Open Source GNU/Linux application that allows you to change the settings of MSI laptops.
 ![Screenshots of MControlCenter](https://user-images.githubusercontent.com/12676622/219121128-0476b54b-3330-40c7-b7ac-8d4a884f8abd.png)
 
@@ -15,10 +17,12 @@ MControlCenter is a Free and Open Source GNU/Linux application that allows you t
  - Change the maximum battery level limit
  - Advanced Fan Speed Control (Since version 0.4)
  - Change other settings such as keyboard backlight mode, USB Power Share, etc.
+ - CLI support (Cooler Boost only)
 
 ## TODO
 
 - Saving multiple fan speed profiles
+- Implement other CLI commands
 
 ## Tested on
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -1,0 +1,58 @@
+/* Copyright (C) 2022  Dmitry Serov
+ *
+ * This file is part of MControlCenter.
+ *
+ * MControlCenter is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * MControlCenter is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with MControlCenter. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "cli.h"
+#include "operate.h"
+
+static Operate operate;
+
+CLI::CLI() {
+    if (!operate.isEcSysModuleLoaded() && !operate.loadEcSysModule()){
+        fprintf(stderr, "Failed to load the ec_sys kernel module\n");
+        exit(1);
+    }
+
+    if(!operate.updateEcData() || operate.getEcVersion().empty()){
+        fprintf(stderr, "Failed to update EC data\n");
+        exit(1);
+    }
+
+    if (!operate.doProbe()) {
+        fprintf(stderr, "Failed probing devices\n");
+        exit(1);
+    }
+}
+
+CLI::~CLI() {
+}
+
+void CLI::setCoolerBoost(Options::State state){
+    bool on = false;
+    if(state == Options::State::TOGGLE){ // TOGGLE
+        on = !operate.getCoolerBoostState();
+    }
+    else{
+        on = state;
+    }
+
+    if(operate.getCoolerBoostState() != on){
+        fprintf(stdout, "%s Cooler Boost\n", ( on ? "Enabling" : "Disabling" ));
+        operate.setCoolerBoostState(on);
+        operate.updateEcData();
+    }
+}

--- a/src/cli.h
+++ b/src/cli.h
@@ -1,0 +1,33 @@
+/* Copyright (C) 2022  Dmitry Serov
+ *
+ * This file is part of MControlCenter.
+ *
+ * MControlCenter is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * MControlCenter is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with MControlCenter. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef CLI_H
+#define CLI_H
+
+#include "options.h"
+
+class CLI {
+
+public:
+    CLI();
+    ~CLI();
+
+    void setCoolerBoost(Options::State on);
+};
+
+#endif // CLI_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,10 +80,10 @@ int main(int argc, char *argv[]) {
         QLocalSocket* socket = server.nextPendingConnection();
         if(socket->waitForConnected() && socket->waitForReadyRead()){
             QByteArray data = socket->readAll();
-            if(std::strcmp(data.data(), "show") == 0){
+            if(std::string(data.data()) == "show"){
                 w.show();
             }
-            else if(std::strcmp(data.data(), "update") == 0){
+            else if(std::string(data.data()) == "update"){
                 w.externalUpdate();
             }
         }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -23,7 +23,7 @@
 #include <QTimer>
 #include <QMessageBox>
 
-Operate operate;
+static Operate operate;
 
 bool isActive = false;
 bool isUpdateDataError = false;
@@ -204,6 +204,11 @@ void MainWindow::realtimeUpdate() {
     updateData();
 }
 
+void MainWindow::externalUpdate() {
+    if(operate.updateEcData())
+        updateData();
+}
+
 void MainWindow::updateData() {
     if (!isUpdateDataError && !operate.getEcVersion().empty()) {
         if (!isActive) {
@@ -221,6 +226,7 @@ void MainWindow::updateData() {
         updateFan2Speed();
         updateKeyboardBrightness();
         updateWebCamState();
+        updateCoolerBoostState();
     } else {
         setTabsEnabled(false);
         isActive = false;
@@ -427,10 +433,10 @@ void MainWindow::updateFanMode() {
 void MainWindow::updateFanSpeedSettings() {
     ui->advancedFanControlCheckBox->setChecked(operate.getFanMode() == fan_mode::advanced_fan_mode);
 
-    QVector fan1SpeedSettings = operate.getFan1SpeedSettings();
-    QVector fan1TempSettings = operate.getFan1TempSettings();
-    QVector fan2SpeedSettings = operate.getFan2SpeedSettings();
-    QVector fan2TempSettings = operate.getFan2TempSettings();
+    QVector<int> fan1SpeedSettings = operate.getFan1SpeedSettings();
+    QVector<int> fan1TempSettings = operate.getFan1TempSettings();
+    QVector<int> fan2SpeedSettings = operate.getFan2SpeedSettings();
+    QVector<int> fan2TempSettings = operate.getFan2TempSettings();
 
     ui->fan1Speed1Slider->setValue(fan1SpeedSettings[0]);
     ui->fan1Speed2Slider->setValue(fan1SpeedSettings[1]);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -35,6 +35,7 @@ Q_OBJECT
 public:
     explicit MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
+    void externalUpdate();
     void updateData();
     static void setUpdateDataError(bool error);
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1,0 +1,85 @@
+/* Copyright (C) 2022  Dmitry Serov
+ *
+ * This file is part of MControlCenter.
+ *
+ * MControlCenter is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * MControlCenter is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with MControlCenter. If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "options.h"
+
+#include <cstring>
+
+Options::Options()
+    :cli(false), cooler_boost(std::nullopt)
+{}
+
+void Options::print_help(std::string program_name)
+{
+    fprintf(stdout, R"(Description
+Syntax: %s [options]
+
+    -B, --coolerboost STATE             toggle fan cooler boost
+    -h                                  show help
+
+Arguments:
+    STATE: can be 'ON', 'OFF' or 'TOGGLE'
+)", program_name.c_str());
+    exit(1);
+}
+
+void Options::process_args(int argc, char** argv)
+{
+    int option_index;
+    while (true)
+    {
+        const auto opt = getopt_long(argc, argv, short_opts.data(), long_opts, &option_index);
+
+        if (-1 == opt){
+            break;
+        }
+
+        switch (opt)
+        {
+            case 0:
+                cli = true;
+                // long option without short equivalent
+            break;
+
+            case 'B':
+                cli = true;
+
+                if(std::strcmp(optarg,"ON") == 0){
+                    cooler_boost = std::optional<Options::State>{Options::State::ON};
+                }
+                else if(std::strcmp(optarg,"OFF") == 0)
+                {
+                    cooler_boost = std::optional<Options::State>{Options::State::OFF};
+                }
+                else if(std::strcmp(optarg,"TOGGLE") == 0)
+                {
+                    cooler_boost = std::optional<Options::State>{Options::State::TOGGLE};
+                }
+                else{
+                    fprintf(stderr, "Wrong TOGGLE value for coolerboost option.\n");
+                    print_help(argv[0]);
+                }
+            break;
+
+            case 'h': // -h or --help
+            case '?': // Unrecognized option
+            default:
+                print_help(argv[0]);
+            break;
+        }
+    }
+}

--- a/src/options.h
+++ b/src/options.h
@@ -1,0 +1,53 @@
+/* Copyright (C) 2022  Dmitry Serov
+ *
+ * This file is part of MControlCenter.
+ *
+ * MControlCenter is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * MControlCenter is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with MControlCenter. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPTIONS_H
+#define OPTIONS_H
+
+#include <getopt.h>
+#include <optional>
+#include <string>
+
+class Options{
+public:
+    Options();
+    ~Options() = default;
+
+    enum State {
+        OFF = 0,
+        ON = 1,
+        TOGGLE = 2
+    };
+
+    bool cli;
+    std::optional<State> cooler_boost;
+
+    void process_args(int argc, char** argv);
+
+private:
+    static constexpr std::string_view const short_opts = "B:h";
+    static constexpr option long_opts[] = {
+        {"coolerboost", required_argument, nullptr, 'B'},
+        {"help",        no_argument, nullptr, 'h'},
+        {nullptr,       no_argument, nullptr, 0}
+    };
+
+    void print_help(std::string program_name);
+};
+
+#endif // OPTIONS_H


### PR DESCRIPTION
- Remove deprecated C-style string comparison using strcmp
- Use native C++ string comparison operator for better readability

![image](https://github.com/user-attachments/assets/1fc872a0-73ac-49be-be8b-20a2514d4e8f)
